### PR TITLE
Promote Chinese contributor entrypoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,17 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Chinese README / 中文说明
+    url: https://github.com/kurtxu88/parallel-worlds/blob/main/README.zh-CN.md
+    about: Start here if you want the project overview in Chinese.
   - name: Roadmap / 路线图
     url: https://github.com/kurtxu88/parallel-worlds/blob/main/docs/roadmap.md
     about: Check the current product direction before proposing large scope changes. 提大方向改动前先看这里。
   - name: Chinese Contributing Guide / 中文贡献指南
     url: https://github.com/kurtxu88/parallel-worlds/blob/main/CONTRIBUTING.zh-CN.md
     about: Read this first if you want to contribute in Chinese.
+  - name: Chinese Troubleshooting / 中文排障指南
+    url: https://github.com/kurtxu88/parallel-worlds/blob/main/docs/troubleshooting.zh-CN.md
+    about: Check this if you are blocked by local setup, Docker, or runtime issues.
   - name: Growth Playbook / 增长手册
     url: https://github.com/kurtxu88/parallel-worlds/blob/main/docs/growth-playbook.md
     about: See how we think about demoability, adoption, and community growth. 了解项目如何做增长与传播。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Parallel Worlds
 
+[English](./README.md) | [中文说明](./README.zh-CN.md) | [中文贡献指南](./CONTRIBUTING.zh-CN.md) | [中文排障指南](./docs/troubleshooting.zh-CN.md)
+
 [![CI](https://github.com/kurtxu88/parallel-worlds/actions/workflows/ci.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/ci.yml)
 [![Release Drafter](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release-drafter.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release-drafter.yml)
 [![Release](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release.yml)
@@ -8,6 +10,15 @@
 ![Parallel Worlds social card](./apps/web/public/social-card.svg)
 
 Parallel Worlds is an open-source AI storytelling app for building playable worlds from short narrative seeds.
+
+> 中文贡献者也欢迎直接参与。
+> 快速入口：
+> [中文 README](./README.zh-CN.md) |
+> [中文贡献指南](./CONTRIBUTING.zh-CN.md) |
+> [中文排障指南](./docs/troubleshooting.zh-CN.md) |
+> [中文 Bug 模板](https://github.com/kurtxu88/parallel-worlds/issues/new?template=bug_report.zh-CN.yml) |
+> [中文功能建议模板](https://github.com/kurtxu88/parallel-worlds/issues/new?template=feature_request.zh-CN.yml) |
+> [中文世界展示模板](https://github.com/kurtxu88/parallel-worlds/issues/new?template=showcase.zh-CN.yml)
 
 Current release line: `v0.1.0`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 # Parallel Worlds
 
+[中文说明](./README.zh-CN.md) | [English README](./README.md) | [中文贡献指南](./CONTRIBUTING.zh-CN.md) | [中文排障指南](./docs/troubleshooting.zh-CN.md)
+
 [![CI](https://github.com/kurtxu88/parallel-worlds/actions/workflows/ci.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/ci.yml)
 [![Release Drafter](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release-drafter.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release-drafter.yml)
 [![Release](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release.yml/badge.svg)](https://github.com/kurtxu88/parallel-worlds/actions/workflows/release.yml)


### PR DESCRIPTION
## Summary
- add visible Chinese contributor links at the top of the main README
- add matching language switch links to the Chinese README
- add Chinese README and troubleshooting links to GitHub issue contact links

## Why
Chinese contributors should be able to discover the right docs and issue templates immediately when they land on the repo, without hunting through the English README first.

## Checks
- git diff --check